### PR TITLE
Add docker scripts for setup and removal of containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:18
 WORKDIR /app
 
 # Install the dotenvx package globally
-RUN curl -sfS https://dotenvx.sh/install.sh | sh
+#RUN curl -sfS https://dotenvx.sh/install.sh | sh
 
 # Copy the package.json and package-lock.json files to the container
 COPY package*.json ./
@@ -20,7 +20,7 @@ RUN npm install
 COPY . .
 
 # Encrypt the .env file
-RUN dotenvx encrypt .env
+#RUN dotenvx encrypt .env > encrypt.log
 
 
 # Expose port 3000

--- a/scripts/docker_remove_server.sh
+++ b/scripts/docker_remove_server.sh
@@ -1,0 +1,2 @@
+docker stop tabu-db-api &&
+docker rm tabu-db-api

--- a/scripts/docker_run_server.sh
+++ b/scripts/docker_run_server.sh
@@ -1,0 +1,2 @@
+docker build -t tabu-db-api . &&
+docker run --name tabu-db-api -p 3001:3001 tabu-db-api


### PR DESCRIPTION
Remove dotenvx encrypt from dockerfile setup since it does not work 
Exposing of port can be added to dockerfile but user still needs to expose ports
to random host ports with the docker run -P (uppercase) flag, 
so it is easier to just bind the exact ports, e.g., docker run -p 3000:3000
Add dockerfile shell scripts for easier docker startup and cleanup

TEST: Docker running and client (browser) sending API requests to localhost with mapped port