### PR TITLE
fix: add try_files directive to handle client-side routing in Nginx

### DIFF
--- a/scripts/tabudb-nginx-setup.sh
+++ b/scripts/tabudb-nginx-setup.sh
@@ -136,6 +136,9 @@ server {
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
         proxy_cache_bypass \$http_upgrade;
+        
+        # Handle client-side routing
+        try_files \$uri \$uri/ /index.html;
     }
 }
 EOF


### PR DESCRIPTION
Refreshing the page on live causes 404 error. This should fix that.